### PR TITLE
Several fixes based on updated pipelines and testing

### DIFF
--- a/infrastructure/environments/cloudformation/full/la/dagster.yaml
+++ b/infrastructure/environments/cloudformation/full/la/dagster.yaml
@@ -80,17 +80,35 @@ Parameters:
     Type: String
     Default: "repository.py"
     Description: Location of the repo.py file that controls the repository
+
+  # Dagster Parameters
   InputLocation:
     Type: String
     Description: |
       The standard location to look for files to ingest into the pipelines. For s3, this must be a ROOT path, no folders
       Example: s3://my-bucket-name
-  OutputLocation:
+  WorkspaceLocation:
     Type: String
     Description: The standard output location for pipeline files. For s3, this must be a ROOT path, no folders.
-  SharedLocation:
+  OutputLocation:
     Type: String
     Description: The location to surface files for the org account
+  ExternalDataLocation:
+    Type: String
+    Description: Location of external data to be used for the pipeline (shouldn't be used in the LA instance)
+    Default: ""
+  CleanPipelineSchedule:
+    Type: String
+    Description: The CRON string used to determine how often the clean file pipeline should run
+    Default: "0 0 * * 1-5"
+  ReportsPipelineSchedule:
+    Type: String
+    Description: The CRON string used to determine how often the Reports pipeline should run. Note that This should never run on the LA instance, so default is date that should never happen.
+    Default: "0 0 0 31 2"
+  AllowedDatasets:
+    Type: String
+    Description: Which datasets to allow to run on the system
+    Default: "ssda903,cin"
 
   # Database Parameters
   DBStorageSize:
@@ -463,7 +481,7 @@ Resources:
               Value: !Ref DBPort
             - Name: OUTPUT_LOCATION
               Value: !Ref OutputLocation
-            - Name: INCOMING_LOCATION
+            - Name: INPUT_LOCATION
               Value: !Ref InputLocation
             - Name: PYTHONLEGACYWINDOWSSTDIO
               Value: "utf8.env"
@@ -530,7 +548,7 @@ Resources:
               Value: !GetAtt CodeServerTaskDefinition.TaskDefinitionArn
             - Name: OUTPUT_LOCATION
               Value: !Ref OutputLocation
-            - Name: INCOMING_LOCATION
+            - Name: INPUT_LOCATION
               Value: !Ref InputLocation
             - Name: PYTHONLEGACYWINDOWSSTDIO
               Value: "utf8.env"
@@ -584,10 +602,6 @@ Resources:
               Value: !Ref CodeServerPipelineRepoLocation
             - Name: PYTHONLEGACYWINDOWSSTDIO
               Value: "utf8.env"
-            - Name: OUTPUT_LOCATION
-              Value: !Ref OutputLocation
-            - Name: INCOMING_LOCATION
-              Value: !Ref InputLocation
             - Name: DAGSTER_POSTGRES_HOST
               Value: !GetAtt DagsterDatabaseCluster.Endpoint.Address
             - Name: DAGSTER_POSTGRES_USER
@@ -602,18 +616,18 @@ Resources:
               Value: "*.csv"
             - Name: DAGSTER_CURRENT_IMAGE
               Value: !Ref UserCode1ImagePath
-            - Name: INPUT_LOCATION_903
-              Value: !Sub "${OutputLocation}/export/PAN"
-            - Name: INPUT_LOCATION
-              Value: !Ref InputLocation
-            - Name: LA_CODE
-              Value: "None"
             - Name: WORKSPACE_LOCATION
-              Value: !Ref OutputLocation
+              Value: !Ref WorkspaceLocation
             - Name: INPUT_LOCATION
               Value: !Ref InputLocation
             - Name: SHARED_LOCATION
-              Value: !Ref SharedLocation
+              Value: !Ref OutputLocation
+            - Name: CLEAN_SCHEDULE
+              Value: !Ref CleanPipelineSchedule
+            - Name: REPORTS_SCHEDULE
+              Value: !Ref ReportsPipelineSchedule
+            - Name: ALLOWED_DATASETS
+              Value: !Ref AllowedDatasets
       Tags:
         - Key: Project
           Value: !Ref ProjectName

--- a/infrastructure/environments/cloudformation/full/la/dagster.yaml
+++ b/infrastructure/environments/cloudformation/full/la/dagster.yaml
@@ -104,7 +104,7 @@ Parameters:
   ReportsPipelineSchedule:
     Type: String
     Description: The CRON string used to determine how often the Reports pipeline should run. Note that This should never run on the LA instance, so default is date that should never happen.
-    Default: "0 0 0 31 2"
+    Default: "0 0 31 2 *"
   AllowedDatasets:
     Type: String
     Description: Which datasets to allow to run on the system

--- a/infrastructure/environments/cloudformation/full/la/s3.yaml
+++ b/infrastructure/environments/cloudformation/full/la/s3.yaml
@@ -138,7 +138,7 @@ Resources:
                 - ec2.amazonaws.com
             Action: "s3:GetObject"
             Resource:
-              - !Join [ "", [ "arn:aws:s3:::", !Ref SharedBucket, "/*" ] ]
+              - !Sub "${SharedBucket.Arn}/*"
           - Effect: Allow
             Principal:
               AWS: !Ref OrgAccountRoleArn
@@ -150,8 +150,8 @@ Resources:
               - "s3:GetObjectAttributes"
               - "s3:GetObjectTagging"
             Resource:
-              - !Join [ "", [ "arn:aws:s3:::", !Ref SharedBucket, "/*" ] ]
-              - !Join [ "", [ "arn:aws:s3:::", !Ref SharedBucket ] ]
+              - !Sub "${SharedBucket.Arn}/*"
+              - !Ref SharedBucket.Arn
 
 
   IngressStorageRole:

--- a/infrastructure/environments/cloudformation/full/la/s3.yaml
+++ b/infrastructure/environments/cloudformation/full/la/s3.yaml
@@ -46,10 +46,10 @@ Conditions:
       - true
 
 Resources:
-  IngressBucket:
+  DataStoreBucket:
     Type: 'AWS::S3::Bucket'
     Properties:
-      BucketName: !Sub "${AppName}-ingress-${OrganisationName}-${Environment}"
+      BucketName: !Sub "${AppName}-data-store-${OrganisationName}-${Environment}"
       AccessControl: Private
       BucketEncryption:
         ServerSideEncryptionConfiguration:
@@ -139,15 +139,19 @@ Resources:
             Action: "s3:GetObject"
             Resource:
               - !Join [ "", [ "arn:aws:s3:::", !Ref SharedBucket, "/*" ] ]
-          #- Effect: Allow
-          #  Principal:
-          #    AWS: !Ref OrgAccountRoleArn
-          #  Action:
-          #    - "s3:GetObject"
-          #    - "s3:ListBucket"
-          #  Resource:
-          #    - !Join [ "", [ "arn:aws:s3:::", !Ref SharedBucket, "/*" ] ]
-          #    - !Join [ "", [ "arn:aws:s3:::", !Ref SharedBucket ] ]
+          - Effect: Allow
+            Principal:
+              AWS: !Ref OrgAccountRoleArn
+            Action:
+              - "s3:GetObject"
+              - "s3:ListBucket"
+              - "s3:GetBucketAcl"
+              - "s3:GetObjectAcl"
+              - "s3:GetObjectAttributes"
+              - "s3:GetObjectTagging"
+            Resource:
+              - !Join [ "", [ "arn:aws:s3:::", !Ref SharedBucket, "/*" ] ]
+              - !Join [ "", [ "arn:aws:s3:::", !Ref SharedBucket ] ]
 
 
   IngressStorageRole:
@@ -174,7 +178,7 @@ Resources:
                   - "s3:PutObject"
                   - "s3:GetObject"
                   - "s3:DeleteObject"
-                Resource: !Sub "${IngressBucket.Arn}/*"
+                Resource: !Sub "${DataStoreBucket.Arn}/*"
 
   WorkspaceStorageRole:
     Type: 'AWS::IAM::Role'
@@ -233,10 +237,10 @@ Resources:
 
 Outputs:
   IngressBucketName:
-    Value: !Ref IngressBucket
+    Value: !Ref DataStoreBucket
     Description: Name of the ingress Amazon S3 bucket with a lifecycle configuration.
   IngressBucketArn:
-    Value: !GetAtt IngressBucket.Arn
+    Value: !GetAtt DataStoreBucket.Arn
     Description: ARN of the ingress store Amazon S3 bucket with a lifecycle configuration
   IngressRoleARN:
     Value: !GetAtt IngressStorageRole.Arn

--- a/infrastructure/environments/cloudformation/full/la/sso2_azure.yaml
+++ b/infrastructure/environments/cloudformation/full/la/sso2_azure.yaml
@@ -52,6 +52,7 @@ Resources:
         - "openid"
         - "email"
         - "aws.cognito.signin.user.admin"
+        - "profile"
       SupportedIdentityProviders:
         - !Sub "${ApplicationName}-${OrganisationName}-AzureADProvider-${EnvironmentName}"
       AllowedOAuthFlowsUserPoolClient: true

--- a/infrastructure/environments/cloudformation/full/organisation/dagster.yaml
+++ b/infrastructure/environments/cloudformation/full/organisation/dagster.yaml
@@ -101,7 +101,7 @@ Parameters:
     Description: The location to look for data files coming from external sources (e.g. ONS, post codes, etc)
   CleanPipelineSchedule:
     Type: String
-    Description: The CRON string used to determine how often the clean file pipeline should run
+    Description: The CRON string used to determine how often the clean file pipeline should run.  Note that This should never run on the Org instance, so default is date that should never happen.
     Default: "0 0 31 2 *"
   ReportsPipelineSchedule:
     Type: String

--- a/infrastructure/environments/cloudformation/full/organisation/dagster.yaml
+++ b/infrastructure/environments/cloudformation/full/organisation/dagster.yaml
@@ -102,7 +102,7 @@ Parameters:
   CleanPipelineSchedule:
     Type: String
     Description: The CRON string used to determine how often the clean file pipeline should run
-    Default: "0 0 0 31 2"
+    Default: "0 0 31 2 *"
   ReportsPipelineSchedule:
     Type: String
     Description: The CRON string used to determine how often the Reports pipeline should run. Note that This should never run on the LA instance, so default is date that should never happen.

--- a/infrastructure/environments/cloudformation/full/organisation/dagster.yaml
+++ b/infrastructure/environments/cloudformation/full/organisation/dagster.yaml
@@ -80,20 +80,37 @@ Parameters:
     Type: String
     Default: "repository.py"
     Description: Location of the repo.py file that controls the repository
+
+  # Dagster Parameters
   InputLocation:
     Type: String
     Description: |
       The standard location to look for files to ingest into the pipelines. For s3, this must be a ROOT path, no folders
       Example: s3://my-bucket-name
+  InputLocationArn:
+    Type: String
+    Description: ARN of the InputLocation bucket
   OutputLocation:
+    Type: String
+    Description: The standard output location for pipeline files. For s3, this must be a ROOT path, no folders.
+  WorkspaceLocation:
     Type: String
     Description: The standard output location for pipeline files. For s3, this must be a ROOT path, no folders.
   ExternalDataLocation:
     Type: String
     Description: The location to look for data files coming from external sources (e.g. ONS, post codes, etc)
-  OfstedExternalDataLocation:
+  CleanPipelineSchedule:
     Type: String
-    Description: The location to look for the Ofsted data (external resource)
+    Description: The CRON string used to determine how often the clean file pipeline should run
+    Default: "0 0 0 31 2"
+  ReportsPipelineSchedule:
+    Type: String
+    Description: The CRON string used to determine how often the Reports pipeline should run. Note that This should never run on the LA instance, so default is date that should never happen.
+    Default: "0 0 * * 1-5"
+  AllowedDatasets:
+    Type: String
+    Description: Which datasets to allow to run on the system
+    Default: "ssda903,cin"
 
   # Database Parameters
   DBStorageSize:
@@ -394,6 +411,21 @@ Resources:
                   - "logs:CreateLogGroup"
                 Resource:
                   - "*"
+        - PolicyName: LASharedSpaceAccess
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "s3:GetObject"
+                  - "s3:ListBucket"
+                  - "s3:GetBucketAcl"
+                  - "s3:GetObjectAcl"
+                  - "s3:GetObjectAttributes"
+                  - "s3:GetObjectTagging"
+                Resource:
+                  - !Ref InputLocationArn
+
       ManagedPolicyArns: # These need to be peared down for security reasons. What is necessary?
         - arn:aws:iam::aws:policy/CloudWatchFullAccess
         - arn:aws:iam::aws:policy/AmazonSSMFullAccess
@@ -461,14 +493,8 @@ Resources:
               Value: !Ref DBName
             - Name: DAGSTER_POSTGRES_PORT
               Value: !Ref DBPort
-            - Name: OUTPUT_LOCATION
-              Value: !Ref OutputLocation
-            - Name: INCOMING_LOCATION
-              Value: !Ref InputLocation
             - Name: PYTHONLEGACYWINDOWSSTDIO
               Value: "utf8.env"
-            - Name: 903_WILDCARDS
-              Value: "*.csv"
             - Name: DAGSTER_CODE_SERVER_TASK
               Value: !GetAtt CodeServerTaskDefinition.TaskDefinitionArn
       Tags:
@@ -528,22 +554,8 @@ Resources:
               Value: !Ref DBPort
             - Name: DAGSTER_CODE_SERVER_TASK
               Value: !GetAtt CodeServerTaskDefinition.TaskDefinitionArn
-            - Name: OUTPUT_LOCATION
-              Value: !Ref OutputLocation
-            - Name: INCOMING_LOCATION
-              Value: !Ref InputLocation
             - Name: PYTHONLEGACYWINDOWSSTDIO
               Value: "utf8.env"
-            - Name: 903_WILDCARDS
-              Value: "*.csv"
-            - Name: INPUT_LOCATION_EXT
-              Value: !Ref ExternalDataLocation
-            - Name: INPUT_LOCATION_903
-              Value: !Sub "${OutputLocation}/Current"
-            - Name: EXTERNAL_DATA_LOCATION
-              Value: !Ref ExternalDataLocation
-            - Name: INPUT_LOCATION
-              Value: !Ref InputLocation
       Tags:
         - Key: Project
           Value: !Ref ProjectName
@@ -588,10 +600,6 @@ Resources:
               Value: !Ref CodeServerPipelineRepoLocation
             - Name: PYTHONLEGACYWINDOWSSTDIO
               Value: "utf8.env"
-            - Name: OUTPUT_LOCATION
-              Value: !Ref OutputLocation
-            - Name: INCOMING_LOCATION
-              Value: !Ref InputLocation
             - Name: DAGSTER_POSTGRES_HOST
               Value: !GetAtt DagsterDatabaseCluster.Endpoint.Address
             - Name: DAGSTER_POSTGRES_USER
@@ -602,22 +610,22 @@ Resources:
               Value: !Ref DBName
             - Name: DAGSTER_POSTGRES_PORT
               Value: !Ref DBPort
-            - Name: 903_WILDCARDS
-              Value: "*.csv"
             - Name: DAGSTER_CURRENT_IMAGE
               Value: !Ref UserCode1ImagePath
-            - Name: INPUT_LOCATION_EXT
-              Value: !Ref ExternalDataLocation
-            - Name: INPUT_LOCATION_903
-              Value: !Sub "${OutputLocation}/export/PAN"
-            - Name: INPUT_LOCATION_OFS
-              Value: !Ref OfstedExternalDataLocation
             - Name: EXTERNAL_DATA_LOCATION
               Value: !Ref ExternalDataLocation
             - Name: INPUT_LOCATION
               Value: !Ref InputLocation
-            - Name: LA_CODE
-              Value: "None"
+            - Name: WORKSPACE_LOCATION
+              Value: !Ref WorkspaceLocation
+            - Name: OUTPUT_LOCATION
+              Value: !Ref OutputLocation
+            - Name: CLEAN_SCHEDULE
+              Value: !Ref CleanPipelineSchedule
+            - Name: REPORTS_SCHEDULE
+              Value: !Ref ReportsPipelineSchedule
+            - Name: ALLOWED_DATASETS
+              Value: !Ref AllowedDatasets
       Tags:
         - Key: Project
           Value: !Ref ProjectName


### PR DESCRIPTION
* Fixed missing SSO profile omission
* Fixed communication error between LA and ORG accounts with s3 bucket permissions and role permissions
* Standardised environment variables so they match what the LIIA pipeline code expects
* Some cleanup of the dagit and daemon services that don't need certain environment variables set
* Reverted the ingest bucket name change back to data store to avoid it being deleted unnecessarily