### PR TITLE
Fix attributes mismatch

### DIFF
--- a/infrastructure/environments/cloudformation/full/la/sso2_azure.yaml
+++ b/infrastructure/environments/cloudformation/full/la/sso2_azure.yaml
@@ -33,10 +33,10 @@ Resources:
       ProviderType: "SAML"
       AttributeMapping:
         email: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
-        given_name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname
-        custom:userprincipalname: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name
         family_name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname
-        custom:groups: http://schemas.microsoft.com/ws/2008/06/identity/claims/groups
+        given_name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname
+        locale: http://schemas.microsoft.com/ws/2008/06/identity/claims/groups
+        name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name
   UserPoolClient:
     Type: AWS::Cognito::UserPoolClient
     DependsOn: UserPoolIdentityProvider

--- a/infrastructure/environments/cloudformation/full/organisation/sso2_azure.yaml
+++ b/infrastructure/environments/cloudformation/full/organisation/sso2_azure.yaml
@@ -32,10 +32,10 @@ Resources:
       ProviderType: "SAML"
       AttributeMapping:
         email: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
-        given_name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname
-        custom:userprincipalname: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name
         family_name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname
-        custom:groups: http://schemas.microsoft.com/ws/2008/06/identity/claims/groups
+        given_name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname
+        locale: http://schemas.microsoft.com/ws/2008/06/identity/claims/groups
+        name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name
   UserPoolClient:
     Type: AWS::Cognito::UserPoolClient
     DependsOn: UserPoolIdentityProvider


### PR DESCRIPTION
Some attribute mappings were incorrect. For instance, locale wasn't present in the cloudformation when it should be as that maps to the user group or LA_Name users should have access to. Using custom attributes in Cognito are less reliable than built-in attributes and so we should use them whenever possible.