### PR TITLE
Removed region wildcard for task usage

### DIFF
--- a/infrastructure/environments/cloudformation/full/la/dagster.yaml
+++ b/infrastructure/environments/cloudformation/full/la/dagster.yaml
@@ -225,7 +225,7 @@ Resources:
                   - "ssm:GetParameters"
                   - "secretsmanager:GetSecretValue"
                 Resource:
-                  - !Sub "arn:aws:ecs:*:${AWS::AccountId}:task/*/*"
+                  - !Sub "arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:task/*/*"
                   - !Sub "arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:task-definition/CodeServerTask:*"
               - Effect: Allow
                 Action:

--- a/infrastructure/environments/cloudformation/full/organisation/dagster.yaml
+++ b/infrastructure/environments/cloudformation/full/organisation/dagster.yaml
@@ -227,7 +227,7 @@ Resources:
                   - "ssm:GetParameters"
                   - "secretsmanager:GetSecretValue"
                 Resource:
-                  - !Sub "arn:aws:ecs:*:${AWS::AccountId}:task/*/*"
+                  - !Sub "arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:task/*/*"
                   - !Sub "arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:task-definition/CodeServerTask:*"
               - Effect: Allow
                 Action:


### PR DESCRIPTION
Generating tasks should be limited to the region defined by the rest of the platform