### PR TITLE
Added missing cloudwatch permission link 

### DIFF
--- a/infrastructure/environments/cloudformation/full/common/scaling.yaml
+++ b/infrastructure/environments/cloudformation/full/common/scaling.yaml
@@ -71,6 +71,22 @@ Resources:
           Arn: !GetAtt FonsScalingLambda.Arn
           Input: '{ "pipelineStatus": "false" }'
 
+  FonsDagsterScalingTurnOnPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt FonsScalingLambda.Arn
+      Action: 'lambda:InvokeFunction'
+      Principal: 'events.amazonaws.com'
+      SourceArn: !GetAtt CloudWatchEventsTurnOnRule.Arn
+
+  FonsDagsterScalingTurnOffPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt FonsScalingLambda.Arn
+      Action: 'lambda:InvokeFunction'
+      Principal: 'events.amazonaws.com'
+      SourceArn: !GetAtt CloudWatchEventsTurnOffRule.Arn
+
   FonsDagsterScalingLambdaRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
The changes allow the cloudwatch cron rule to actually allow the execution of the lambda function which was the missing piece and why this wasn't executing currently.