### PR TITLE
Enable Glacier backup for important s3 buckets

### DIFF
--- a/infrastructure/environments/cloudformation/full/la/s3.yaml
+++ b/infrastructure/environments/cloudformation/full/la/s3.yaml
@@ -57,6 +57,14 @@ Resources:
               SSEAlgorithm: AES256
       VersioningConfiguration:
         Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: GlacierRule
+            Status: Enabled
+            ExpirationInDays: !Ref AutoFileDeletion
+            Transitions:
+              - TransitionInDays: 1
+                StorageClass: GLACIER
 
 
   DataStoreBucket:
@@ -179,6 +187,14 @@ Resources:
               SSEAlgorithm: AES256
       VersioningConfiguration:
         Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: GlacierRule
+            Status: Enabled
+            ExpirationInDays: !Ref AutoFileDeletion
+            Transitions:
+              - TransitionInDays: 1
+                StorageClass: GLACIER
 
   SharedBucket:
     Type: 'AWS::S3::Bucket'

--- a/infrastructure/environments/cloudformation/full/organisation/s3.yaml
+++ b/infrastructure/environments/cloudformation/full/organisation/s3.yaml
@@ -81,6 +81,14 @@ Resources:
               SSEAlgorithm: AES256
       VersioningConfiguration:
         Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: GlacierRule
+            Status: Enabled
+            ExpirationInDays: !Ref AutoFileDeletion
+            Transitions:
+              - TransitionInDays: 1
+                StorageClass: GLACIER
 
   EgressBucket:
     Type: 'AWS::S3::Bucket'


### PR DESCRIPTION
This updates the backup buckets to utilise GLACIER storage after a day of being in the backup location.  This should satisfy the "offsite" backup storage location as it moves the backups to tapes.

So, backups move as follows:
1. Live bucket (e.g. data-store)
2. Copy files to backup bucket (e.g. data-store-backup)
3. After a day, move the backup files to glacier

The default time is used to match the standard deletion time frame. In this case 6 years (2190 days)

![image](https://github.com/user-attachments/assets/3a952969-8f6d-4d5a-8b82-ff0630b12fd0)
