### PR TITLE
build: give codeserver containers access to docker creds

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -22,6 +22,23 @@ files that regional authorities can access. To accomplish this, we have two acco
 2. Organisation - Where the files that were created from the LA are combined with regional and other data (e.g. ONS, 
 postcode, etc) to create output that can be used for analysis at a regional level.
 
+Note: When ECS is used to run the Dagster code server, ECS will spin up a new container for each Dagster
+job. Spinning up these containers requires pulling a docker image each time - in order to avoid rate 
+limits, we need to authenticate to docker as a paid docker user. Social Finance has the docker Pro user
+sysadmsocialfinance - the credentials are stored in the Secrets Manager in the SFDL Master AWS account. 
+If the infrastructure/hosting responsibilities have been handed over to a client, the client must create their 
+own docker user and store the associated credentials. If Social Finance are hosting the infrastructure, 
+then after creating a new account, but before standing up the rest of the infrastructure:
+1. Navigate to the AWS SFDL Master account 
+2. Go to the Secrets Manager and select dockerhub-sysadmin-credentials-5Lb3FI
+3. Edit the policy against the secret by adding f"arn:aws:iam::{account_id}:root" to the Principal. We cannot use
+a specific role here as the role must exist before it is added to the IAM policy. In order to get around this, we give
+access to the root user in the target account and it is the job of the target account to appropriately delegate access
+to the role that needs it (defined in the CodeServerTaskExecutionRole in the dagster Cloudformation stack).
+4. Still within the AWS SFDL Master account, navigate to the KMS
+5. Go to the DataPlatform-ParameterStore-Key key -> Other AWS accounts and add the new account number
+Note: a custom encryption key must be used and shared separately because AWS-managed keys cannot be shared across accounts.
+
 In order to set this up, use the full directory in the cloudformation folder. Bring the infrastructure up in the following order:
 1. Organisation
    1. common/ids.yaml
@@ -38,7 +55,7 @@ In order to set this up, use the full directory in the cloudformation folder. Br
       ```python
       f"arn:aws:s3:::fons-shared-{org}-prod"
       ```
-   6. orgamisation/dagster.yaml
+   6. organisation/dagster.yaml
    7. common/scaling.yaml
       * Add the lambda zip file to the appropriate bucket before creating this infrastructure. Follow
       these [instructions](../infrastructure/environments/cloudformation/full/common/lambda/ecs_scale/README.md)

--- a/infrastructure/environments/cloudformation/full/la/dagster.yaml
+++ b/infrastructure/environments/cloudformation/full/la/dagster.yaml
@@ -393,6 +393,7 @@ Resources:
   CodeServerTaskExecutionRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Sub "${ProjectName}-${RegionConfig}-CodeServerTaskExecutionRole"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -406,6 +407,19 @@ Resources:
         - arn:aws:iam::aws:policy/AmazonSSMFullAccess
         - arn:aws:iam::aws:policy/AmazonElasticContainerRegistryPublicReadOnly
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+      Policies:
+        - PolicyName: ReadRemoteSecretDockerCredentials
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource: "arn:aws:secretsmanager:eu-west-2:260477567664:secret:dockerhub-sysadmin-credentials-5Lb3FI"
+              - Effect: Allow
+                Action:
+                  - kms:Decrypt
+                Resource: "arn:aws:kms:eu-west-2:260477567664:key/69dd8f98-e08c-4410-840f-ab1ea78ef2b2"
 
   CodeServerTaskRole:
     Type: AWS::IAM::Role
@@ -585,6 +599,8 @@ Resources:
       ContainerDefinitions:
         - Name: user_code
           Image: !Ref UserCode1ImagePath
+          RepositoryCredentials:
+            CredentialsParameter: "arn:aws:secretsmanager:eu-west-2:260477567664:secret:dockerhub-sysadmin-credentials-5Lb3FI"
           Memory: !Ref CodeServerMemory
           PortMappings:
             - ContainerPort: 4000

--- a/infrastructure/environments/cloudformation/full/organisation/dagster.yaml
+++ b/infrastructure/environments/cloudformation/full/organisation/dagster.yaml
@@ -395,6 +395,7 @@ Resources:
   CodeServerTaskExecutionRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Sub "${ProjectName}-${RegionConfig}-CodeServerTaskExecutionRole"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -408,6 +409,19 @@ Resources:
         - arn:aws:iam::aws:policy/AmazonSSMFullAccess
         - arn:aws:iam::aws:policy/AmazonElasticContainerRegistryPublicReadOnly
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+      Policies:
+        - PolicyName: ReadRemoteSecretDockerCredentials
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource: "arn:aws:secretsmanager:eu-west-2:260477567664:secret:dockerhub-sysadmin-credentials-5Lb3FI"
+              - Effect: Allow
+                Action:
+                  - kms:Decrypt
+                Resource: "arn:aws:kms:eu-west-2:260477567664:key/69dd8f98-e08c-4410-840f-ab1ea78ef2b2"
 
   CodeServerTaskRole:
     Type: AWS::IAM::Role
@@ -614,6 +628,8 @@ Resources:
       ContainerDefinitions:
         - Name: user_code
           Image: !Ref UserCode1ImagePath
+          RepositoryCredentials:
+            CredentialsParameter: "arn:aws:secretsmanager:eu-west-2:260477567664:secret:dockerhub-sysadmin-credentials-5Lb3FI"
           Memory: !Ref CodeServerMemory
           PortMappings:
             - ContainerPort: 4000


### PR DESCRIPTION
I've set up credentials for the sysadmsocialfinance docker hub user. They are stored in the secrets manager of the SFDL AWS account. This PR (and by following the associated instructions) should give access to those credentials in other accounts where they will be used to pull only the code server image (as that is the one that spins up loads of new containers). We can further expand these credentials to be used against all the dagster images if need be.