### PR TITLE
feat: add datasync bucket policy

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -48,6 +48,8 @@ In order to set this up, use the full directory in the cloudformation folder. Br
    3. organisation/s3.yaml
       * Upload external data to the external data S3 bucket - this can be copied from
       staging
+      * If you want to enable DataSync which will copy all files from the egress bucket to a destination bucket,
+      include the ARN of the data sync role in the parameters.
    4. common/general_key_access.yaml
       * Use the output from this to configure Heroku env vars.
    5. organisation/VPC.yaml

--- a/infrastructure/environments/cloudformation/full/organisation/s3.yaml
+++ b/infrastructure/environments/cloudformation/full/organisation/s3.yaml
@@ -35,11 +35,22 @@ Parameters:
     Default: true
     Description: Enable cross-account access to the shared S3 bucket
 
+  DataSyncRole:
+    Type: String
+    Default: ""
+    Description: The ARN of the DataSync role that will be used to access the egress S3 bucket for data transfer.
+
+
 Conditions:
   EnableCrossAccountAccessCondition:
     Fn::Equals:
       - Ref: EnableCrossAccountAccess
       - true
+  EnableEgressBucketDataSync:
+    Fn::Not:
+      - Fn::Equals:
+          - Ref: DataSyncRole
+          - ""
 
 Resources:
   ExternalDataStoreBucket:
@@ -191,6 +202,27 @@ Resources:
                 - ec2.amazonaws.com
             Action: "s3:GetObject"
             Resource: !Join [ "", [ "arn:aws:s3:::", !Ref EgressBucket, "/*" ] ]
+          - Fn::If:
+            - EnableEgressBucketDataSync
+            - Effect: Allow
+              Sid: AllowDataSyncAcrossAccounts
+              Principal:
+                AWS:
+                  - !Ref DataSyncRole
+              Action:
+                - "s3:GetBucketLocation"
+                - "s3:ListBucket"
+                - "s3:ListBucketMultipartUploads"
+                - "s3:GetObject"
+                - "s3:ListMultipartUploadParts"
+                - "s3:GetObjectTagging"
+              Resource:
+                - !GetAtt EgressBucket.Arn
+                - !Join
+                  - ''
+                  - - !GetAtt EgressBucket.Arn
+                    - "/*"
+            - !Ref AWS::NoValue
 
   ExternalDataStoreStorageRole:
     Type: 'AWS::IAM::Role'


### PR DESCRIPTION
Allow a DataSync resource to access the egress bucket by providing a DataSync role ARN to the bucket policy. This has been applied in staging.