### PR TITLE
fix: allow access to secrets for code server sg

### DIFF
--- a/infrastructure/environments/cloudformation/full/organisation/vpc.yaml
+++ b/infrastructure/environments/cloudformation/full/organisation/vpc.yaml
@@ -465,6 +465,10 @@ Resources:
           FromPort: 443
           ToPort: 443
           SourceSecurityGroupId: !Ref ExportSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          SourceSecurityGroupId: !Ref CodeServerSecurityGroup
       SecurityGroupEgress:
         - CidrIp: 0.0.0.0/0
           IpProtocol: -1


### PR DESCRIPTION
Allows code server group to access secrets endpoint which is needed for dockerhub credentials