### PR TITLE
fix: adjust secret access for ecs tasks

### DIFF
--- a/infrastructure/environments/cloudformation/full/organisation/dagster.yaml
+++ b/infrastructure/environments/cloudformation/full/organisation/dagster.yaml
@@ -239,28 +239,9 @@ Resources:
             Principal:
               Service: ecs-tasks.amazonaws.com
             Action: sts:AssumeRole
-      Policies:
-        - PolicyName: DagitTaskExecutionSSM
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - "ssm:GetParameters"
-                  - "secretsmanager:GetSecretValue"
-                Resource:
-                  - !Sub "arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:task/*/*"
-                  - !Sub "arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:task-definition/CodeServerTask:*"
-              - Effect: Allow
-                Action:
-                  - "ecs:DescribeTaskDefinition"
-                Resource:
-                  - "*"
-      ManagedPolicyArns: # These need to be peared down for security reasons. What is necessary?
+      ManagedPolicyArns: # These need to be pared down for security reasons. What is necessary?
         - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
         - arn:aws:iam::aws:policy/CloudWatchFullAccess
-        - arn:aws:iam::aws:policy/AmazonElasticContainerRegistryPublicReadOnly
-        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
 
   DagitTaskRole:
     Type: AWS::IAM::Role
@@ -313,11 +294,8 @@ Resources:
                   - "ecs:DescribeTaskDefinition"
                 Resource:
                   - "*"
-      ManagedPolicyArns:        # These need to be peared down for security reasons. What is necessary?
+      ManagedPolicyArns:        # These need to be pared down for security reasons. What is necessary?
         - arn:aws:iam::aws:policy/CloudWatchFullAccess
-        - arn:aws:iam::aws:policy/AmazonSSMFullAccess
-        - arn:aws:iam::aws:policy/AmazonElasticContainerRegistryPublicReadOnly
-        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
         - arn:aws:iam::aws:policy/AmazonS3FullAccess
 
   DaemonTaskExecutionRole:
@@ -330,12 +308,9 @@ Resources:
             Principal:
               Service: ecs-tasks.amazonaws.com
             Action: sts:AssumeRole
-      ManagedPolicyArns: # These need to be peared down for security reasons. What is necessary?
+      ManagedPolicyArns: # These need to be pared down for security reasons. What is necessary?
         - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
         - arn:aws:iam::aws:policy/CloudWatchFullAccess
-        - arn:aws:iam::aws:policy/AmazonSSMFullAccess
-        - arn:aws:iam::aws:policy/AmazonElasticContainerRegistryPublicReadOnly
-        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
 
   DaemonTaskRole:
     Type: AWS::IAM::Role
@@ -389,11 +364,8 @@ Resources:
                 Condition:
                   StringLike:
                     iam:PassedToService: "ecs-tasks.amazonaws.com"
-      ManagedPolicyArns: # These need to be peared down for security reasons. What is necessary?
+      ManagedPolicyArns: # These need to be pared down for security reasons. What is necessary?
         - arn:aws:iam::aws:policy/CloudWatchFullAccess
-        - arn:aws:iam::aws:policy/AmazonSSMFullAccess
-        - arn:aws:iam::aws:policy/AmazonElasticContainerRegistryPublicReadOnly
-        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
         - arn:aws:iam::aws:policy/AmazonS3FullAccess
 
   CodeServerTaskExecutionRole:
@@ -407,12 +379,9 @@ Resources:
             Principal:
               Service: ecs-tasks.amazonaws.com
             Action: sts:AssumeRole
-      ManagedPolicyArns: # These need to be peared down for security reasons. What is necessary?
+      ManagedPolicyArns: # These need to be pared down for security reasons. What is necessary?
         - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
         - arn:aws:iam::aws:policy/CloudWatchFullAccess
-        - arn:aws:iam::aws:policy/AmazonSSMFullAccess
-        - arn:aws:iam::aws:policy/AmazonElasticContainerRegistryPublicReadOnly
-        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
       Policies:
         - PolicyName: ReadRemoteSecretDockerCredentials
           PolicyDocument:
@@ -477,11 +446,8 @@ Resources:
                   - !Ref InputLocationArn
                   - !Sub "${InputLocationArn}/*"
 
-      ManagedPolicyArns: # These need to be peared down for security reasons. What is necessary?
+      ManagedPolicyArns: # These need to be pared down for security reasons. What is necessary?
         - arn:aws:iam::aws:policy/CloudWatchFullAccess
-        - arn:aws:iam::aws:policy/AmazonSSMFullAccess
-        - arn:aws:iam::aws:policy/AmazonElasticContainerRegistryPublicReadOnly
-        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
         - arn:aws:iam::aws:policy/AmazonS3FullAccess
 
   DagsterCluster:

--- a/infrastructure/environments/cloudformation/full/organisation/vpc.yaml
+++ b/infrastructure/environments/cloudformation/full/organisation/vpc.yaml
@@ -468,6 +468,10 @@ Resources:
         - IpProtocol: tcp
           FromPort: 443
           ToPort: 443
+          SourceSecurityGroupId: !Ref DaemonSecurityGroup
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
           SourceSecurityGroupId: !Ref CodeServerSecurityGroup
       SecurityGroupEgress:
         - CidrIp: 0.0.0.0/0


### PR DESCRIPTION
The optional export to azure task included a secrets manager security group. The daemon security group needs access to it in order to get the database credentials.

We have also removed perms on the dagit task as it shouldn't need secrets access to function, but the container build was failing because of the listed perms. So the rest of the ECS perms have been cleaned up as well. They will need another review i.e. to further limit to specific log groups rather than logs all access.