### PR TITLE
feat: version the lambda artifacts

### DIFF
--- a/.github/workflows/build_lambda_base.yml
+++ b/.github/workflows/build_lambda_base.yml
@@ -51,6 +51,11 @@ jobs:
       - name: Install Poetry Export Plugin
         run: poetry self add poetry-plugin-export
 
+      - name: Get lambda version
+        id: version
+        run: |
+          echo "version=$(poetry version -s)" >> $GITHUB_OUTPUT
+
       - name: Build Lambda package
         run: |
           rm -rf build
@@ -70,6 +75,6 @@ jobs:
       - name: Upload artifact for deploy jobs
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ inputs.artifact-name }}
+          name: ${{ inputs.artifact-name }}-${{ steps.version.outputs.version }}
           path: ${{ inputs.lambda-directory }}/build
           retention-days: ${{ inputs.retention-days }}

--- a/infrastructure/environments/cloudformation/full/common/scaling.yaml
+++ b/infrastructure/environments/cloudformation/full/common/scaling.yaml
@@ -53,6 +53,9 @@ Parameters:
     Type: String
     Description: Whether the turn on rule is enabled. If it is not, set to DISABLED
     Default: "ENABLED"
+  LambdaVersion:
+    Type: String
+    Description: Version of the Lambda function to use. When this is updated, the Lambda function will update itself to the new version.
 
 Resources:
   CloudWatchEventsTurnOnRule:
@@ -120,7 +123,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: !Ref LambdaCodeBucket
-        S3Key: ecs-scaling-lambda.zip
+        S3Key: !Sub "ecs-scaling/ecs-scaling-lambda-${LambdaVersion}.zip"
       Role: !GetAtt FonsDagsterScalingLambdaRole.Arn
       Handler: handler.lambda_handler
       Runtime: python3.13

--- a/infrastructure/environments/cloudformation/full/la/triggered_job.yaml
+++ b/infrastructure/environments/cloudformation/full/la/triggered_job.yaml
@@ -32,6 +32,9 @@ Parameters:
     Type: String
     Description: Namespace for private network.
     Default: my-namespace.local
+  LambdaVersion:
+    Type: String
+    Description: Version of the Lambda function to use. When this is updated, the Lambda function will update itself to the new version.
 
 Resources:
   TriggerDagsterJobLambdaRole:
@@ -62,7 +65,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: !Ref LambdaCodeBucket
-        S3Key: trigger-dagster-job.zip
+        S3Key: !Sub "trigger-dagster-job/trigger-dagster-job-${LambdaVersion}.zip"
       Role: !GetAtt TriggerDagsterJobLambdaRole.Arn
       Handler: handler.lambda_handler
       Runtime: python3.13


### PR DESCRIPTION
The goal here is to make deploying updated lambdas an easier process. This PR gets the version from the pyproject.toml file and includes it in the artifact name. It also defines the lambda functions themselves such that they will look for an artifact (in the S3 bucket) with a version (passed as a parameter to the Cloudformation stack).

After this, we will add a helper script such that a user with appropriate permissions can, via CLI, deploy a lambda zip to multiple environments easily. This means the whole workflow would be:
1. Open a PR to update the lambda (e.g. with features or security dependencies) and the version number in pyproject.toml
2. Merge to main of PR runs the action to create the zip
3. Download the zip locally
4. Run the (to be created) helper script which, with a version number passed, will upload the zip to the S3 bucket and redeploy the cloudformation stack. 
5. On redeploy, lambda function sees a new S3 key and reloads itself (rather than requiring a manual reload)