### PR TITLE
feat: add logs for scaling lambda

### DIFF
--- a/infrastructure/environments/cloudformation/full/common/scaling.yaml
+++ b/infrastructure/environments/cloudformation/full/common/scaling.yaml
@@ -56,6 +56,10 @@ Parameters:
   LambdaVersion:
     Type: String
     Description: Version of the Lambda function to use. When this is updated, the Lambda function will update itself to the new version.
+  LogRetentionTimeDays:
+    Type: String
+    Default: 30
+    Description: The number of days to store Cloudwatch Logs
 
 Resources:
   CloudWatchEventsTurnOnRule:
@@ -95,6 +99,12 @@ Resources:
       Principal: 'events.amazonaws.com'
       SourceArn: !GetAtt CloudWatchEventsTurnOffRule.Arn
 
+  LambdaLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "${ProjectName}-${OrganisationName}-ScalingLambda-${Environment}"
+      RetentionInDays: !Ref LogRetentionTimeDays
+
   FonsDagsterScalingLambdaRole:
     Type: AWS::IAM::Role
     Properties:
@@ -117,6 +127,16 @@ Resources:
                   - !Ref DaemonServiceARN
                   - !Ref DagitServiceARN
                   - !Ref CodeServerServiceARN
+        - PolicyName: CloudWatchLogsPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !GetAtt LambdaLogGroup.Arn
 
   FonsScalingLambda:
     Type: AWS::Lambda::Function
@@ -128,6 +148,8 @@ Resources:
       Handler: handler.lambda_handler
       Runtime: python3.13
       Timeout: 60
+      LoggingConfig:
+        LogGroup: !Ref LambdaLogGroup
       Environment:
         Variables:
           ECS_CLUSTER_NAME: !Ref ECSClusterName


### PR DESCRIPTION
Logs for staging environments were being created previously due to a change that hadn't been checked into the repo! When cross-checked, there have been no logs created on prod environments for this lambda. It's not critical, but good practice (and helpful for debugging) for us to record these runs. 

This will be tested tonight when the lambda runs on staging.