### PR TITLE
feat: add deployment script for lambdas

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,32 @@
+# Deployment
+
+Deploying changes to the infrastructure of the data platform comprises different processes.
+Currently, infrastructure is defined through Cloudformation stacks in yaml files. When changes 
+are made and merged to main, the stacks must be manually updated in each environment.
+
+## Lambda Functions
+When changes are made to the code of the lambda functions, either first or third party, 
+the code must be packaged and uploaded to the appropriate S3 bucket and the associated lambda
+cloudformation stack redeployed to use the new version.
+
+1. Once a PR with changes to the lambda code is merged to main, open a PR to update the version number defined
+in the `pyproject.toml` file. 
+2. On approval of this PR, confirm that the appropriate Github Action has run and created a zip file
+of the lambda code.
+3. Download the lambda zip file from the Github Action artifacts.
+4. Run the `release_lambda.sh` script to upload the zip file to the appropriate S3 bucket and redeploy the lambda stack. 
+The script has two dependencies that must be installed on your machine and available in your PATH:
+- [AWS CLI](https://aws.amazon.com/cli/)
+- yq 
+
+The script takes four arguments:
+- AWS profile name to use for the CLI - this requires that you have logged into the AWS cli and have saved [profiles](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html) for the target accounts
+- an evironment name - this must match the entries in the `deploy_config.yaml`. If you do not have this file, ask a team member for it
+- the path to the lambda zip file that was downloaded from the Github Action artifacts
+- the S3 prefix i.e. the folder in which the zip file should be uploaded
+
+```bash
+./release_lambda.sh <AWS_PROFILE> <environment> <path-to-lambda-zip> <s3-prefix>
+```
+
+This script will ask for your confirmation before deploying the changeset to the lambda stack.

--- a/deployment/deploy_config.yaml
+++ b/deployment/deploy_config.yaml
@@ -1,0 +1,41 @@
+environments:
+  la-staging:
+    lambda_stack: Fons-Staging-Platform-Dagster-Scaling
+    lambda_bucket_name: fons-lambda-code-la-staging
+    dagster_stack:
+  org-staging:
+    lambda_stack:
+    lambda_bucket_name:
+    dagster_stack:
+  london-la-staging:
+    lambda_stack:
+    lambda_bucket_name:
+    dagster_stack:
+  london-org-staging:
+    lambda_stack:
+    lambda_bucket_name:
+    dagster_stack:
+  eoe-la-staging:
+    lambda_stack:
+    storalambda_bucket_namege_stack:
+    dagster_stack:
+  eoe-org-staging:
+    lambda_stack:
+    lambda_bucket_name:
+    dagster_stack:
+  gmca-la-staging:
+    lambda_stack:
+    lambda_bucket_name:
+    dagster_stack:
+  gmca-org-staging:
+    lambda_stack:
+    lambda_bucket_name:
+    dagster_stack:
+  se-la-staging:
+    lambda_stack:
+    lambda_bucket_name:
+    dagster_stack:
+  se-org-staging:
+    lambda_stack:
+    lambda_bucket_name:
+    dagster_stack:

--- a/deployment/release_lambda.sh
+++ b/deployment/release_lambda.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PROFILE="${1}"
+ENVIRONMENT="${2}"
+ZIP_FILE="${3}"
+S3_KEY_PREFIX="${4:-}"
+
+CONFIG_FILE="deploy_config.yaml"
+
+REGION="${AWS_REGION:-eu-west-2}"
+
+# Validate inputs
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+    echo "Config file not found: ${CONFIG_FILE}"
+    exit 1
+fi
+
+if [[ ! -f "${ZIP_FILE}" ]]; then
+    echo "Zip file not found: ${ZIP_FILE}"
+    exit 1
+fi
+
+LAMBDA_STACK=$(yq e ".environments.\"${ENVIRONMENT}\".lambda_stack" "${CONFIG_FILE}")
+LAMBDA_BUCKET_NAME=$(yq e ".environments.\"${ENVIRONMENT}\".lambda_bucket_name" "${CONFIG_FILE}")
+
+if [[ "${LAMBDA_STACK}" == "null" ]]; then
+    echo "Unknown environment: ${ENVIRONMENT}"
+    exit 1
+fi
+
+# Get filename and version from zip file
+FILENAME=$(basename "${ZIP_FILE}")
+
+VERSION=$(echo "${FILENAME}" | sed -E 's/.*-([0-9]+\.[0-9]+\.[0-9]+)\.zip/\1/')
+
+if [[ "${VERSION}" == "${FILENAME}" ]]; then
+    echo "Could not determine version from filename"
+    echo "Expected: my-lambda-1.2.4.zip"
+    exit 1
+fi
+
+echo "Checking AWS credentials..."
+
+aws sts get-caller-identity \
+    --profile "${PROFILE}" \
+    --region "${REGION}" \
+    >/dev/null
+
+# Upload zip file to S3 and verify
+S3_KEY="${S3_KEY_PREFIX}/${FILENAME}"
+FILE_UPLOAD_LOCATION="s3://${LAMBDA_BUCKET_NAME}/${S3_KEY}"
+
+echo
+echo "Uploading:"
+echo "$FILE_UPLOAD_LOCATION"
+echo
+
+aws s3 cp \
+    "${ZIP_FILE}" \
+    "${FILE_UPLOAD_LOCATION}" \
+    --profile "${PROFILE}" \
+    --region "${REGION}"
+
+aws s3api head-object \
+    --bucket "${LAMBDA_BUCKET_NAME}" \
+    --key "${S3_KEY}" \
+    --profile "${PROFILE}" \
+    --region "${REGION}" >/dev/null
+
+# Create change set for lambda stack
+CHANGE_SET_NAME="lambda-$(date +%Y%m%d-%H%M%S)"
+
+echo
+echo "Creating change set..."
+echo
+
+# Get current parameters from the stack
+PARAMETER_KEYS=$(aws cloudformation describe-stacks \
+  --stack-name "${LAMBDA_STACK}" \
+  --profile "${PROFILE}" \
+  --query "Stacks[0].Parameters[].ParameterKey" \
+  --output text)
+
+# Build parameter list, keeping old parameters and updating the LambdaVersion parameter
+PARAMETERS=()
+for PARAMETER_KEY in $PARAMETER_KEYS
+do
+    if [[ "${PARAMETER_KEY}" == "LambdaVersion" ]]
+    then
+        PARAMETERS+=(
+          "ParameterKey=${PARAMETER_KEY},ParameterValue=${VERSION}"
+        )
+    else
+        PARAMETERS+=(
+          "ParameterKey=${PARAMETER_KEY},UsePreviousValue=true"
+        )
+    fi
+done
+
+aws cloudformation create-change-set \
+    --stack-name "${LAMBDA_STACK}" \
+    --change-set-name "${CHANGE_SET_NAME}" \
+    --change-set-type UPDATE \
+    --use-previous-template \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --parameters "${PARAMETERS[@]}" \
+    --profile "${PROFILE}" \
+    --region "${REGION}"
+
+aws cloudformation wait change-set-create-complete \
+    --stack-name "${LAMBDA_STACK}" \
+    --change-set-name "${CHANGE_SET_NAME}" \
+    --profile "${PROFILE}" \
+    --region "${REGION}"
+
+# Display planned changes for user confirmation
+echo
+echo "===================================================="
+echo "ENVIRONMENT : ${ENVIRONMENT}"
+echo "VERSION     : ${VERSION}"
+echo "STACK       : ${LAMBDA_STACK}"
+echo "BUCKET      : ${LAMBDA_BUCKET_NAME}"
+echo "===================================================="
+
+echo
+echo "Planned changes:"
+echo
+
+aws cloudformation describe-change-set \
+    --stack-name "${LAMBDA_STACK}" \
+    --change-set-name "${CHANGE_SET_NAME}" \
+    --query 'Changes[].ResourceChange.[Action,LogicalResourceId,ResourceType,Replacement]' \
+    --output table \
+    --profile "${PROFILE}" \
+    --region "${REGION}"
+
+echo
+read -p "Execute change set? (y/N): " CONFIRM
+
+if [[ ! "${CONFIRM}" =~ ^[Yy]$ ]]; then
+
+    echo "Deleting change set..."
+
+    aws cloudformation delete-change-set \
+        --stack-name "${LAMBDA_STACK}" \
+        --change-set-name "${CHANGE_SET_NAME}" \
+        --profile "${PROFILE}" \
+        --region "${REGION}"
+
+    echo "Cancelled"
+
+    exit 0
+fi
+
+# Execute change set
+aws cloudformation execute-change-set \
+    --stack-name "${LAMBDA_STACK}" \
+    --change-set-name "${CHANGE_SET_NAME}" \
+    --profile "${PROFILE}" \
+    --region "${REGION}"
+
+echo
+echo "Waiting for deployment..."
+
+aws cloudformation wait stack-update-complete \
+    --stack-name "${LAMBDA_STACK}" \
+    --profile "${PROFILE}" \
+    --region "${REGION}"
+
+echo "===================================================="
+echo "Deployment complete"
+echo "Environment : ${ENVIRONMENT}"
+echo "Version     : ${VERSION}"
+echo "===================================================="


### PR DESCRIPTION
This script helps deploy lambdas to prod environments. It does require logging into each specific env before so very open to upgrades! Thoughts on potentially gitignoring the config file (currently has not prod data in it).

Test output shown below:

<img width="660" height="836" alt="image" src="https://github.com/user-attachments/assets/2d2e4976-fc50-4c9d-ac94-dbbef027a55c" />
